### PR TITLE
Merge v0.13 for OCaml 4.11.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 _build
 *.install
 *.merlin
+_opam
 

--- a/README-MinaProtocol.md
+++ b/README-MinaProtocol.md
@@ -1,0 +1,8 @@
+# Changes for MinaProtocol
+
+`rpc_parallel` was forked from `janestreet/rpc_parallel`. The first changes
+for MinaProtocol were made atop tag v0.12.0 in branch `coda`. Bazel
+support was added later.
+
+For OCaml 4.11.2, the Jane Street code at v0.13.0 was merged into the fork.
+Other than fixing minor merge conflicts, no other changes were made.

--- a/example/number_stats.ml
+++ b/example/number_stats.ml
@@ -1,3 +1,4 @@
+open Core
 open Jane
 open Async
 

--- a/example/rpc_direct_pipe.ml
+++ b/example/rpc_direct_pipe.ml
@@ -28,7 +28,9 @@ module Sum_worker = struct
             ~f:(fun acc x ->
               let acc = acc + x in
               let output = sprintf "Sum_worker.sum: %i\n" acc in
-              let _ = Rpc.Pipe_rpc.Direct_stream_writer.write writer output in
+              let (_ : [ `Closed | `Flushed of unit Deferred.t ]) =
+                Rpc.Pipe_rpc.Direct_stream_writer.write writer output
+              in
               acc)
             (List.init arg ~f:Fn.id)
         in

--- a/example/workers_as_masters.ml
+++ b/example/workers_as_masters.ml
@@ -76,7 +76,9 @@ module Primary_worker = struct
               ~on_failure:Error.raise
               ()
           in
-          ignore (Bag.add workers (next_worker_name (), secondary_worker)))
+          ignore
+            (Bag.add workers (next_worker_name (), secondary_worker)
+             : (string * Secondary_worker.worker) Bag.Elt.t))
         >>| ignore
       ;;
 

--- a/example/workers_as_masters.ml
+++ b/example/workers_as_masters.ml
@@ -143,7 +143,8 @@ let command =
          >>=? fun () ->
          Primary_worker.Connection.run conn ~f:Primary_worker.functions.ping ~arg:()
          >>|? fun ping_results ->
-         List.map ping_results ~f:(fun s -> sprintf "Primary worker #%i: %s" worker_id s))
+         List.map ping_results ~f:(fun s ->
+           sprintf "Primary worker #%i: %s" worker_id s))
        >>|? fun l -> List.iter (List.join l) ~f:(printf "%s\n%!"))
 ;;
 

--- a/rpc_parallel.opam
+++ b/rpc_parallel.opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.08.0"}
   "async"
   "core"
   "core_kernel"

--- a/rpc_parallel.opam
+++ b/rpc_parallel.opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.07.0" & < "4.08.0"}
   "async"
   "core"
   "core_kernel"

--- a/rpc_parallel.opam
+++ b/rpc_parallel.opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.07.0" & < "4.08.0"}
+  "ocaml" {>= "4.07.0"}
   "async"
   "core"
   "core_kernel"

--- a/rpc_parallel.opam
+++ b/rpc_parallel.opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+version: "v0.13.0"
 maintainer: "opensource@janestreet.com"
 authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
 homepage: "https://github.com/janestreet/rpc_parallel"
@@ -10,12 +11,12 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.08.0"}
-  "async"
-  "core"
-  "core_kernel"
-  "ppx_jane"
-  "sexplib"
+  "ocaml"       {>= "4.08.0"}
+  "async"       {>= "v0.13" & < "v0.14"}
+  "core"        {>= "v0.13" & < "v0.14"}
+  "core_kernel" {>= "v0.13" & < "v0.14"}
+  "ppx_jane"    {>= "v0.13" & < "v0.14"}
+  "sexplib"     {>= "v0.13" & < "v0.14"}
   "dune"        {>= "1.5.1"}
 ]
 synopsis: "Type-safe parallel library built on top of Async_rpc"

--- a/rpc_parallel.opam
+++ b/rpc_parallel.opam
@@ -16,7 +16,7 @@ depends: [
   "core_kernel"
   "ppx_jane"
   "sexplib"
-  "dune"        {build & >= "1.5.1"}
+  "dune"        {>= "1.5.1"}
 ]
 synopsis: "Type-safe parallel library built on top of Async_rpc"
 description: "

--- a/rpc_parallel.opam
+++ b/rpc_parallel.opam
@@ -13,9 +13,10 @@ depends: [
   "ocaml" {>= "4.07.0"}
   "async"
   "core"
+  "core_kernel"
   "ppx_jane"
   "sexplib"
-  "dune"     {build & >= "1.5.1"}
+  "dune"        {build & >= "1.5.1"}
 ]
 synopsis: "Type-safe parallel library built on top of Async_rpc"
 description: "

--- a/src/dune
+++ b/src/dune
@@ -1,3 +1,4 @@
 (library (name rpc_parallel) (public_name rpc_parallel)
- (libraries async core core.daemon sexplib core.uuid)
+ (libraries async core core.daemon core_kernel.pairing_heap sexplib
+  core.uuid)
  (preprocess (pps ppx_jane)))

--- a/src/fd_redirection.ml
+++ b/src/fd_redirection.ml
@@ -3,5 +3,6 @@ open Core
 type t =
   [ `Dev_null
   | `File_append of string
-  | `File_truncate of string ]
+  | `File_truncate of string
+  ]
 [@@deriving sexp]

--- a/src/fd_redirection.mli
+++ b/src/fd_redirection.mli
@@ -3,5 +3,6 @@ open! Core
 type t =
   [ `Dev_null
   | `File_append of string
-  | `File_truncate of string ]
+  | `File_truncate of string
+  ]
 [@@deriving sexp]

--- a/src/map_reduce.ml
+++ b/src/map_reduce.ml
@@ -1,4 +1,5 @@
 open Core
+open Poly
 open Async
 module Heap = Pairing_heap
 

--- a/src/map_reduce.ml
+++ b/src/map_reduce.ml
@@ -1,5 +1,6 @@
 open Core
 open Async
+module Heap = Pairing_heap
 
 module Half_open_interval = struct
   module T = struct

--- a/src/map_reduce.mli
+++ b/src/map_reduce.mli
@@ -7,6 +7,7 @@ open! Async
 module Config : sig
   type t
 
+
   (** Default is to create the same number of local workers as the cores in local
       machine. All spawned workers will their redirect stdout and stderr to the same
       file. *)
@@ -14,8 +15,8 @@ module Config : sig
     :  ?local:int
     -> ?remote:(_ Remote_executable.t * int) list
     -> ?cd:string (** default / *)
-    -> redirect_stderr:[`Dev_null | `File_append of string]
-    -> redirect_stdout:[`Dev_null | `File_append of string]
+    -> redirect_stderr:[ `Dev_null | `File_append of string ]
+    -> redirect_stdout:[ `Dev_null | `File_append of string ]
     -> unit
     -> t
 end
@@ -90,8 +91,7 @@ module Make_map_function (S : Map_function_spec) :
 val map_unordered
   :  Config.t
   -> 'a Pipe.Reader.t
-  -> m:(module
-         Map_function
+  -> m:(module Map_function
          with type Param.t = 'param
           and type Input.t = 'a
           and type Output.t = 'b)
@@ -104,8 +104,7 @@ val map_unordered
 val map
   :  Config.t
   -> 'a Pipe.Reader.t
-  -> m:(module
-         Map_function
+  -> m:(module Map_function
          with type Param.t = 'param
           and type Input.t = 'a
           and type Output.t = 'b)
@@ -120,8 +119,7 @@ val map
 val find_map
   :  Config.t
   -> 'a Pipe.Reader.t
-  -> m:(module
-         Map_function
+  -> m:(module Map_function
          with type Param.t = 'param
           and type Input.t = 'a
           and type Output.t = 'b option)
@@ -187,8 +185,7 @@ module Make_map_reduce_function (S : Map_reduce_function_spec) :
 val map_reduce_commutative
   :  Config.t
   -> 'a Pipe.Reader.t
-  -> m:(module
-         Map_reduce_function
+  -> m:(module Map_reduce_function
          with type Param.t = 'param
           and type Accum.t = 'accum
           and type Input.t = 'a)
@@ -206,8 +203,7 @@ val map_reduce_commutative
 val map_reduce
   :  Config.t
   -> 'a Pipe.Reader.t
-  -> m:(module
-         Map_reduce_function
+  -> m:(module Map_reduce_function
          with type Param.t = 'param
           and type Accum.t = 'accum
           and type Input.t = 'a)

--- a/src/parallel.ml
+++ b/src/parallel.ml
@@ -1660,7 +1660,7 @@ module Make (S : Worker_spec) = struct
       let r, w = Pipe.create () in
       let new_output =
         Log.Output.create
-          ~flush:(fun () -> Deferred.ignore (Pipe.downstream_flushed w))
+          ~flush:(fun () -> Deferred.ignore_m (Pipe.downstream_flushed w))
           (fun msgs ->
              if not (Pipe.is_closed w)
              then Queue.iter msgs ~f:(fun msg -> Pipe.write_without_pushback w msg);

--- a/src/parallel.ml
+++ b/src/parallel.ml
@@ -57,7 +57,10 @@ let worker_implementations = Worker_type_id.Table.create ~size:1 ()
 module Worker_command_args = struct
   type t =
     | Decorate of string
-    | User_supplied of { args : string list; pass_name : bool }
+    | User_supplied of
+        { args : string list
+        ; pass_name : bool
+        }
   [@@deriving sexp]
 end
 

--- a/src/parallel.ml
+++ b/src/parallel.ml
@@ -772,7 +772,7 @@ module Make (S : Worker_spec) = struct
     | Executable_location.Local ->
       Process.create
         ~prog:(Utils.our_binary ())
-        ~argv0:Sys.argv.(0)
+        ~argv0:(Sys.get_argv ()).(0)
         ~args:worker_command_args
         ~env:(`Extend env)
         ()

--- a/src/parallel.ml
+++ b/src/parallel.ml
@@ -46,7 +46,7 @@ module Worker_implementations = struct
         ('state, 'connection_state) Utils.Internal_connection_state.t
           Rpc.Implementation.t
           list
-      -> t
+        -> t
 end
 
 (* Applications of the [Make()] functor have the side effect of populating an
@@ -301,28 +301,28 @@ module Function = struct
     | Piped :
         ('worker, 'query, 'response) Function_piped.t
         * ('r, 'response Pipe.Reader.t) Type_equal.t
-      -> ('worker, 'query, 'r) t_internal
+        -> ('worker, 'query, 'r) t_internal
     | Directly_piped :
         ('worker, 'query, 'response) Function_piped.t
-      -> ( 'worker
-         , 'query
-           * ('response Rpc.Pipe_rpc.Pipe_message.t -> Rpc.Pipe_rpc.Pipe_response.t)
-         , Rpc.Pipe_rpc.Id.t )
-           t_internal
+        -> ( 'worker
+           , 'query
+             * ('response Rpc.Pipe_rpc.Pipe_message.t -> Rpc.Pipe_rpc.Pipe_response.t)
+           , Rpc.Pipe_rpc.Id.t )
+             t_internal
     | One_way :
         ('worker, 'query) Function_one_way.t
-      -> ('worker, 'query, unit) t_internal
+        -> ('worker, 'query, unit) t_internal
     | Reverse_piped :
         ('worker, 'query, 'update, 'response, 'in_progress) Function_reverse_piped.t
         * ('q, 'query * 'in_progress) Type_equal.t
-      -> ('worker, 'q, 'response) t_internal
+        -> ('worker, 'q, 'response) t_internal
 
   type ('worker, 'query, 'response) t =
     | T :
         ('query -> 'query_internal)
         * ('worker, 'query_internal, 'response_internal) t_internal
         * ('response_internal -> 'response)
-      -> ('worker, 'query, 'response) t
+        -> ('worker, 'query, 'response) t
 
   module Direct_pipe = struct
     type nonrec ('worker, 'query, 'response) t =

--- a/src/parallel_intf.ml
+++ b/src/parallel_intf.ml
@@ -254,6 +254,22 @@ module type Worker = sig
        -> (t * Connection.t) Deferred.t)
         with_spawn_args
   end
+
+  (** This module is used for internal testing of the rpc_parallel library. *)
+  module For_internal_testing : sig
+    module Spawn_in_foreground_result : sig
+      type 'a t =
+        ( 'a * Process.t
+        , Error.t * [`Worker_process of Unix.Exit_or_signal.t Deferred.t option] )
+          Result.t
+    end
+
+    val spawn_in_foreground :
+      (shutdown_on:'a Shutdown_on(Spawn_in_foreground_result).t
+       -> worker_state_init_arg
+       -> 'a)
+        with_spawn_args
+  end
 end
 
 module type Functions = sig

--- a/src/parallel_intf.ml
+++ b/src/parallel_intf.ml
@@ -118,7 +118,7 @@ module type Worker = sig
 
     val close : t -> unit Deferred.t
     val close_finished : t -> unit Deferred.t
-    val close_reason : t -> on_close:[`started | `finished] -> Info.t Deferred.t
+    val close_reason : t -> on_close:[ `started | `finished ] -> Info.t Deferred.t
     val is_closed : t -> bool
   end
 
@@ -180,23 +180,23 @@ module type Worker = sig
 
       [redirect_stdout] and [redirect_stderr] specify stdout and stderr of the worker
       process. *)
-  val spawn :
-    (?umask:int (** defaults to use existing umask *)
-     -> shutdown_on:'a Shutdown_on(Or_error).t
-     -> redirect_stdout:Fd_redirection.t
-     -> redirect_stderr:Fd_redirection.t
-     -> worker_state_init_arg
-     -> 'a)
-      with_spawn_args
+  val spawn
+    : (?umask:int (** defaults to use existing umask *)
+       -> shutdown_on:'a Shutdown_on(Or_error).t
+       -> redirect_stdout:Fd_redirection.t
+       -> redirect_stderr:Fd_redirection.t
+       -> worker_state_init_arg
+       -> 'a)
+        with_spawn_args
 
-  val spawn_exn :
-    (?umask:int (** defaults to use existing umask *)
-     -> shutdown_on:'a Shutdown_on(Monad.Ident).t
-     -> redirect_stdout:Fd_redirection.t
-     -> redirect_stderr:Fd_redirection.t
-     -> worker_state_init_arg
-     -> 'a)
-      with_spawn_args
+  val spawn_exn
+    : (?umask:int (** defaults to use existing umask *)
+       -> shutdown_on:'a Shutdown_on(Monad.Ident).t
+       -> redirect_stdout:Fd_redirection.t
+       -> redirect_stderr:Fd_redirection.t
+       -> worker_state_init_arg
+       -> 'a)
+        with_spawn_args
 
   module Spawn_in_foreground_result : sig
     type 'a t = ('a * Process.t) Or_error.t
@@ -207,21 +207,21 @@ module type Worker = sig
 
       Remember to call [Process.wait] on the returned [Process.t] to avoid zombie
       processes. *)
-  val spawn_in_foreground :
-    (shutdown_on:'a Shutdown_on(Spawn_in_foreground_result).t
-     -> worker_state_init_arg
-     -> 'a)
-      with_spawn_args
+  val spawn_in_foreground
+    : (shutdown_on:'a Shutdown_on(Spawn_in_foreground_result).t
+       -> worker_state_init_arg
+       -> 'a)
+        with_spawn_args
 
   module Spawn_in_foreground_exn_result : sig
     type 'a t = 'a * Process.t
   end
 
-  val spawn_in_foreground_exn :
-    (shutdown_on:'a Shutdown_on(Spawn_in_foreground_exn_result).t
-     -> worker_state_init_arg
-     -> 'a)
-      with_spawn_args
+  val spawn_in_foreground_exn
+    : (shutdown_on:'a Shutdown_on(Spawn_in_foreground_exn_result).t
+       -> worker_state_init_arg
+       -> 'a)
+        with_spawn_args
 
   (** [shutdown] attempts to connect to a worker. Upon success, [Shutdown.shutdown 0] is
       run in the worker. If you want strong guarantees that a worker did shutdown, consider
@@ -236,23 +236,23 @@ module type Worker = sig
         Uses of [spawn_and_connect] that disregard [t] can likely be replaced with [spawn
         ~shutdown_on:Disconnect]. If [t] is used for reconnecting, then you can use [spawn]
         followed by [Connection.client]. *)
-    val spawn_and_connect :
-      (?umask:int
-       -> redirect_stdout:Fd_redirection.t
-       -> redirect_stderr:Fd_redirection.t
-       -> connection_state_init_arg:connection_state_init_arg
-       -> worker_state_init_arg
-       -> (t * Connection.t) Or_error.t Deferred.t)
-        with_spawn_args
+    val spawn_and_connect
+      : (?umask:int
+         -> redirect_stdout:Fd_redirection.t
+         -> redirect_stderr:Fd_redirection.t
+         -> connection_state_init_arg:connection_state_init_arg
+         -> worker_state_init_arg
+         -> (t * Connection.t) Or_error.t Deferred.t)
+          with_spawn_args
 
-    val spawn_and_connect_exn :
-      (?umask:int
-       -> redirect_stdout:Fd_redirection.t
-       -> redirect_stderr:Fd_redirection.t
-       -> connection_state_init_arg:connection_state_init_arg
-       -> worker_state_init_arg
-       -> (t * Connection.t) Deferred.t)
-        with_spawn_args
+    val spawn_and_connect_exn
+      : (?umask:int
+         -> redirect_stdout:Fd_redirection.t
+         -> redirect_stderr:Fd_redirection.t
+         -> connection_state_init_arg:connection_state_init_arg
+         -> worker_state_init_arg
+         -> (t * Connection.t) Deferred.t)
+          with_spawn_args
   end
 
   (** This module is used for internal testing of the rpc_parallel library. *)
@@ -260,15 +260,15 @@ module type Worker = sig
     module Spawn_in_foreground_result : sig
       type 'a t =
         ( 'a * Process.t
-        , Error.t * [`Worker_process of Unix.Exit_or_signal.t Deferred.t option] )
+        , Error.t * [ `Worker_process of Unix.Exit_or_signal.t Deferred.t option ] )
           Result.t
     end
 
-    val spawn_in_foreground :
-      (shutdown_on:'a Shutdown_on(Spawn_in_foreground_result).t
-       -> worker_state_init_arg
-       -> 'a)
-        with_spawn_args
+    val spawn_in_foreground
+      : (shutdown_on:'a Shutdown_on(Spawn_in_foreground_result).t
+         -> worker_state_init_arg
+         -> 'a)
+          with_spawn_args
   end
 end
 
@@ -521,7 +521,7 @@ module type Parallel = sig
       used, require a [State.t] as an argument. If you don't need the [State.t] anymore,
       just pattern match on it. *)
   module State : sig
-    type t = private [< `started]
+    type t = private [< `started ]
 
     val get : unit -> t option
   end

--- a/src/parallel_managed.ml
+++ b/src/parallel_managed.ml
@@ -73,7 +73,8 @@ module Make (S : Parallel.Worker_spec) = struct
 
   type conn =
     [ `Pending of Unmanaged.Connection.t Or_error.t Ivar.t
-    | `Connected of Unmanaged.Connection.t ]
+    | `Connected of Unmanaged.Connection.t
+    ]
 
   let sexp_of_t t = [%sexp_of: Unmanaged.t] t.unmanaged
   let id t = t.id
@@ -141,7 +142,8 @@ module Make (S : Parallel.Worker_spec) = struct
     (Unmanaged.Connection.close_finished connection
      >>> fun () ->
      match Hashtbl.find workers id with
-     | None -> (* [kill] was called, don't report closed connection *)
+     | None ->
+       (* [kill] was called, don't report closed connection *)
        ()
      | Some _ ->
        Hashtbl.remove workers id;

--- a/src/parallel_managed.mli
+++ b/src/parallel_managed.mli
@@ -70,6 +70,7 @@ module type Worker = sig
     -> arg:'query
     -> 'response Deferred.t
 
+
   (** Using these functions will not result in [on_failure] reporting a closed
       connection, unlike running the [shutdown] function. *)
   val kill : t -> unit Or_error.t Deferred.t

--- a/src/remote_executable.ml
+++ b/src/remote_executable.ml
@@ -1,4 +1,5 @@
 open Core
+open Poly
 open Async
 
 type 'a t =

--- a/src/remote_executable.mli
+++ b/src/remote_executable.mli
@@ -11,9 +11,9 @@ type 'a t
     sshing into this host *)
 val existing_on_host
   :  executable_path:string
-  -> ?strict_host_key_checking:[`No | `Ask | `Yes]
+  -> ?strict_host_key_checking:[ `No | `Ask | `Yes ]
   -> string
-  -> [`Undeletable] t
+  -> [ `Undeletable ] t
 
 (** [copy_to_host ~executable_dir ?strict_host_key_checking host] will copy the currently
     running executable to the desired host and path. It will keep the same name but add a
@@ -21,13 +21,13 @@ val existing_on_host
     option used when sshing into this host *)
 val copy_to_host
   :  executable_dir:string
-  -> ?strict_host_key_checking:[`No | `Ask | `Yes]
+  -> ?strict_host_key_checking:[ `No | `Ask | `Yes ]
   -> string
-  -> [`Deletable] t Or_error.t Deferred.t
+  -> [ `Deletable ] t Or_error.t Deferred.t
 
 (** [delete t] will delete a remote executable that was copied over by a previous call to
     [copy_to_host] *)
-val delete : [`Deletable] t -> unit Or_error.t Deferred.t
+val delete : [ `Deletable ] t -> unit Or_error.t Deferred.t
 
 (** Get the underlying path, host, and host_key_checking *)
 val path : _ t -> string

--- a/src/utils.ml
+++ b/src/utils.ml
@@ -1,4 +1,5 @@
 open Core
+open Poly
 open Async
 
 module Worker_id = struct

--- a/src/utils.mli
+++ b/src/utils.mli
@@ -57,7 +57,7 @@ val our_md5 : unit -> string Or_error.t Deferred.t
 
 (* Determine in what context the current executable is running *)
 
-val whoami : unit -> [`Worker | `Master]
+val whoami : unit -> [ `Worker | `Master ]
 
 (* Clear any environment variables that this library has set *)
 
@@ -68,5 +68,5 @@ val clear_env : unit -> unit
 val create_worker_env : extra:(string * string) list -> (string * string) list Or_error.t
 
 val to_daemon_fd_redirection
-  :  [`Dev_null | `File_append of string | `File_truncate of string]
+  :  [ `Dev_null | `File_append of string | `File_truncate of string ]
   -> Daemon.Fd_redirection.t


### PR DESCRIPTION
Merge the Jane Street sources at tag `v0.13` into the `coda` branch, fixing some small merge conflicts, to enable building with OCaml 4.11.2.

Add a `README` for Mina.

Tested by building Mina with OCaml 4.11.2, running a local network.