### PR TITLE
Fix warning about non-erasable optional argument

### DIFF
--- a/src/map_reduce.ml
+++ b/src/map_reduce.ml
@@ -143,7 +143,7 @@ module Make_rpc_parallel_worker (S : Rpc_parallel_worker_spec) = struct
   type run_input_type = S.Run_input.t
   type run_output_type = S.Run_output.t
 
-  let spawn_exn how param ?cd ~redirect_stderr ~redirect_stdout =
+  let spawn_exn how param ?cd ~redirect_stderr ~redirect_stdout () =
     Parallel_worker.spawn_exn
       ~how
       ?cd
@@ -183,7 +183,7 @@ module Make_rpc_parallel_worker (S : Rpc_parallel_worker_spec) = struct
           param
           ?cd
           ~redirect_stderr:(redirect_stderr :> Fd_redirection.t)
-          ~redirect_stdout:(redirect_stdout :> Fd_redirection.t))
+          ~redirect_stdout:(redirect_stdout :> Fd_redirection.t) ())
     in
     let%map local_workers, remote_workers =
       Deferred.both


### PR DESCRIPTION
Add a unit arg to a function so its optional args are erasable (warning in OCaml 4.14).